### PR TITLE
scoped ignoreErrors variable

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -42,7 +42,7 @@ Agenda.prototype.database = function(url, collection, options) {
 
   this._db = mongo.db(url, options).collection(collection);
 
-  ignoreErrors = function() {};
+  var ignoreErrors = function() {};
   this._db.ensureIndex("nextRunAt", ignoreErrors)
           .ensureIndex("lockedAt", ignoreErrors)
           .ensureIndex("name", ignoreErrors)


### PR DESCRIPTION
Without this variable scoped, ignoreErrors leaked into the global scope.