### PR TITLE
Fix for when _findAndLockNextJob returns multiple jobs.

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -20,7 +20,7 @@ var Agenda = module.exports = function(config) {
   if (config.db) {
     this.database(config.db.address, config.db.collection, config.db.options);
   } else if (config.mongo) {
-    this._db =  config.mongo;
+    this._db = config.mongo;
   }
 };
 
@@ -183,7 +183,7 @@ Agenda.prototype.saveJob = function(job, cb) {
   delete props.unique;
 
   props.lastModifiedBy = this._name;
-  
+
   var now = new Date(),
       protect = {},
       update = { $set: props };
@@ -191,8 +191,7 @@ Agenda.prototype.saveJob = function(job, cb) {
 
   if (id) {
     this._db.findAndModify({_id: id}, {}, update, {new: true}, processDbResult);
-  }
-  else if (props.type == 'single') {
+  } else if (props.type == 'single') {
     if (props.nextRunAt && props.nextRunAt <= now) {
       protect.nextRunAt = props.nextRunAt;
       delete props.nextRunAt;
@@ -314,7 +313,7 @@ function unlockJobs(done) {
   function getJobId(j) {
     return j.attrs._id;
   }
-  
+
   var jobIds = this._jobQueue.map(getJobId)
        .concat(this._runningJobs.map(getJobId));
   this._db.update({_id: { $in: jobIds } }, { $set: { lockedAt: null } }, {multi: true}, done);
@@ -324,7 +323,7 @@ function processJobs(extraJob) {
   if (!this._processInterval) {
     return;
   }
-  
+
   var definitions = this._definitions,
     jobName,
     jobQueue = this._jobQueue,
@@ -354,7 +353,12 @@ function processJobs(extraJob) {
       }
 
       if (job) {
-        jobQueue.unshift(job);
+        if( Array.isArray(job) ) {
+          jobQueue = job.concat(jobQueue);
+        } else {
+          jobQueue.unshift(job);
+        }
+
         jobQueueFilling(name);
         jobProcessing();
       }
@@ -374,8 +378,7 @@ function processJobs(extraJob) {
 
     if (job.attrs.nextRunAt < now) {
       runOrRetry();
-    }
-    else {
+    } else {
       setTimeout(runOrRetry, job.attrs.nextRunAt - now);
     }
 


### PR DESCRIPTION
After working out how Agenda pulls in jobs for processing, I noticed
that the _findAndLockNextJob method could return multiple jobs, which
ends up breaking jobs with the same definition.  The query grabs and
updates the list of jobs whose lock time is passed or should be ran,
meaning if you have multiple of the same jobs running and shut
down the server, it will end up never running those jobs again.

I do need to pick @rschmukler's brain about how to properly get tests
for these methods, as it seems that the methods in question are
private and unreachable using Mocha.

Fixes #131 

I'm mostly creating this PR right now to run tests, as I'm pushing this from a computer without Mocha / MongoDB installed.  Any ideas on how to get proper tests done for this issue @rschmukler / @nwkeeley?