### PR TITLE
docs(readme): event handler should use .on

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ agenda.on('complete', function(job) {
 - `success:job name` - called when a job finishes successfully
 
 ```js
-agenda.once('success:send email', function(job) {
+agenda.on('success:send email', function(job) {
   console.log("Sent Email Successfully to: %s", job.attrs.data.to);
 });
 ```


### PR DESCRIPTION
While `agenda.once('event', cb)` works, it will, as the method implies, only run the event once which is highly unlikely to be the desired behavior.