### PR TITLE
Check if job is disabled before running

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -336,7 +336,7 @@ function processJobs(extraJob) {
   } else {
     // On the fly lock a job
     var now = new Date();
-    self._db.findAndModify({ _id: extraJob.attrs._id, lockedAt: null }, {}, { $set: { lockedAt: now } }, function(err, resp) {
+    self._db.findAndModify({ _id: extraJob.attrs._id, lockedAt: null, disabled: { $ne: true } }, {}, { $set: { lockedAt: now } }, function(err, resp) {
       if (resp) {
         jobQueue.unshift(extraJob);
         jobProcessing();

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -1029,7 +1029,7 @@ describe('Job', function() {
         job.save();
 
         setTimeout(function() {
-          jobs.jobs({name: 'everyRunTest1'}, function(err, res) {
+          jobs.jobs({name: 'everyDisabledTest'}, function(err, res) {
             expect(counter).to.be(0);
             jobs.stop(done);
           });

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -1012,6 +1012,30 @@ describe('Job', function() {
         n.on('error', serviceError);
       });
 
+      it('should not run if job is disabled', function(done) {
+        var counter = 0;
+
+        jobs.define('everyDisabledTest', function(job, cb) {
+          counter++;
+          cb();
+        });
+
+        var job = jobs.every(10, 'everyDisabledTest');
+
+        jobs.start();
+
+        job.disable();
+
+        job.save();
+
+        setTimeout(function() {
+          jobs.jobs({name: 'everyRunTest1'}, function(err, res) {
+            expect(counter).to.be(0);
+            jobs.stop(done);
+          });
+        }, jobTimeout);
+      });
+
     });
 
     describe('schedule()', function() {


### PR DESCRIPTION
When using `.every()` and `.disable()` `disabled` isn’t checked when
the job is saved, resulting in the job running.

Related to issue #144