### PR TITLE
Emit events when Agenda init is ready or has failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ agenda.define('delete old users', function(job, done) {
   User.remove({lastLogIn: { $lt: twoDaysAgo }}, done);
 });
 
-agenda.every('3 minutes', 'delete old users');
+agenda.on('ready', function() {
+  agenda.every('3 minutes', 'delete old users');
+  
+  // Alternatively, you could also do:
+  agenda.every('*/3 * * * *', 'delete old users');
 
-// Alternatively, you could also do:
-agenda.every('*/3 * * * *', 'delete old users');
-
-agenda.start();
+  agenda.start();
+});
 
 ```
 
@@ -66,14 +68,18 @@ agenda.define('send email report', {priority: 'high', concurrency: 10}, function
   }, done);
 });
 
-agenda.schedule('in 20 minutes', 'send email report', {to: 'admin@example.com'});
-agenda.start();
+agenda.on('ready', function() {
+  agenda.schedule('in 20 minutes', 'send email report', {to: 'admin@example.com'});
+  agenda.start();
+});
 ```
 
 ```js
-var weeklyReport = agenda.create('send email report', {to: 'another-guy@example.com'})
-weeklyReport.repeatEvery('1 week').save();
-agenda.start();
+agenda.on('ready', function() {
+  var weeklyReport = agenda.create('send email report', {to: 'another-guy@example.com'})
+  weeklyReport.repeatEvery('1 week').save();
+  agenda.start();
+});
 ```
 
 # Full documentation
@@ -83,6 +89,7 @@ mapped to a database collection and load the jobs from within.
 
 ## Table of Contents
 - [Configuring an agenda](#configuring-an-agenda)
+- [Agenda Events](#agenda-events)
 - [Defining job processors](#defining-job-processors)
 - [Creating jobs](#creating-jobs)
 - [Managing jobs](#managing-jobs)
@@ -133,6 +140,8 @@ You can also specify it during instantiation.
 ```js
 var agenda = new Agenda({db: { address: 'localhost:27017/agenda-test', collection: 'agendaJobs' }});
 ```
+
+Agenda will emit a `ready` event (see [Agenda Events](#agenda-events)) when properly connected to the database and it is safe to start using Agenda.
 
 ### mongo(mongoClientInstance)
 
@@ -251,6 +260,19 @@ You can also specify it during instantiation
 
 ```js
 var agenda = new Agenda({defaultLockLifetime: 10000});
+```
+
+## Agenda Events
+
+An instance of an agenda will emit the following events:
+
+- `ready` - called when Agenda mongo connection is successfully opened
+- `error` - called when Agenda mongo connection process has thrown an error
+
+```js
+agenda.on('ready', function() {
+  agenda.start();
+});
 ```
 
 ## Defining Job Processors

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -37,7 +37,13 @@ var Agenda = module.exports = function(config, cb) {
   this._jobQueue = [];
   this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; //10 minute default lockLifetime
   if (config.db) {
+    var self = this;
     this.database(config.db.address, config.db.collection, config.db.options, function(err, coll) {
+      if (err) {
+        self.emit('error', err);
+      } else {
+        self.emit('ready');
+      }
       if (cb) {
         cb(err, coll);
       }


### PR DESCRIPTION
Latest Agenda release (0.7.0) has breaking changes (see: https://github.com/rschmukler/agenda/issues/213). Connecting to MongoDB is now done asynchronously (a callback is now passed), thus all calls to Agenda public methods (like `start`, `every`, etc.) need to be delayed until Agenda mongoDB connection is ready.
This PR add a `ready` event we can hook on.