### PR TITLE
Rollback job completion callback to pre-0.7.0

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -1,7 +1,7 @@
-/** @package 
+/** @package
 
     job.js
-    
+
     21/04/2015 NF   Removed database code. ie. From Job.remove()
 
   Last change: NF 21/04/2015 1:20:47 PM
@@ -178,20 +178,11 @@ Job.prototype.run = function(cb) {
 
         self.attrs.lastFinishedAt = new Date();
         self.attrs.lockedAt = null;
-
-        if (self.attrs.nextRunAt) {
-          self.save(postCommit);
-        } else {
-          self.remove(function(removeErr) {
-            postCommit(removeErr, self);
-          });
-        }
-
-        function postCommit(commitErr, job) {
-          cb && cb(err || commitErr, job);
+        self.save(function(saveErr, job) {
+          cb && cb(err || saveErr, job);
           agenda.emit('complete', self);
           agenda.emit('complete:' + self.attrs.name, self);
-        }
+        });
       };
 
       try {


### PR DESCRIPTION
Fix another breaking change brought by release 0.7.0 (https://github.com/rschmukler/agenda/commit/4246c3bded7864a6896a771f4dacb5b8edee3635)
Besides switching to mongodb-native driver, the commit also change how completed jobs are handled in a very opinionated way: All non recurrent jobs (failed ones too) are now removed from the database.
That change might be a good idea, we should debate on it, but it needs to wait a new major release.