### PR TITLE
Emit ready event when using config.mongo

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -51,6 +51,7 @@ var Agenda = module.exports = function(config, cb) {
   } else if (config.mongo) {
     this._mdb = config.mongo;
     this.db_init( config.db ? config.db.collection : undefined );    // NF 20/04/2015
+    this.emit('ready');
   }
 };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -152,6 +152,7 @@ Job.prototype.fail = function(reason) {
     reason = reason.message;
   }
   this.attrs.failReason = reason;
+  this.attrs.failCount = (this.attrs.failCount || 0) + 1;
   this.attrs.failedAt = new Date();
   return this;
 };
@@ -169,17 +170,19 @@ Job.prototype.run = function(cb) {
       var jobCallback = function(err) {
         if (err) {
           self.fail(err);
-          agenda.emit('fail', err, self);
-          agenda.emit('fail:' + self.attrs.name, err, self);
-        } else {
-          agenda.emit('success', self);
-          agenda.emit('success:' + self.attrs.name, self);
         }
 
         self.attrs.lastFinishedAt = new Date();
         self.attrs.lockedAt = null;
         self.save(function(saveErr, job) {
           cb && cb(err || saveErr, job);
+          if (err) {
+            agenda.emit('fail', err, self);
+            agenda.emit('fail:' + self.attrs.name, err, self);
+          } else {
+            agenda.emit('success', self);
+            agenda.emit('success:' + self.attrs.name, self);
+          }
           agenda.emit('complete', self);
           agenda.emit('complete:' + self.attrs.name, self);
         });


### PR DESCRIPTION
`config.mongo` is doing synchronous work, but added ready event for being consistent with `config.db` behavior (https://github.com/rschmukler/agenda/issues/213#issuecomment-151317062)