### PR TITLE
job priority fix

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -96,7 +96,7 @@ Agenda.prototype.database = function(url, collection, options, cb) {
  */
 Agenda.prototype.db_init = function( collection ){
   this._collection = this._mdb.collection(collection || 'agendaJobs');
-  this._collection.createIndexes([{
+  /*this._collection.createIndexes([{
                                   "key": {"name" : 1, "priority" : -1, "lockedAt" : 1, "nextRunAt" : 1, "disabled" : 1},
                                   "name": "findAndLockNextJobIndex1"
                                 }, {
@@ -105,7 +105,7 @@ Agenda.prototype.db_init = function( collection ){
                                 }],
                                 function( err, result ){
                                   if (err) throw err;
-                                });
+                                });*/
 };
 
 Agenda.prototype.name = function(name) {

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -417,16 +417,32 @@ function processJobs(extraJob) {
   function jobQueueFilling(name) {
     var now = new Date();
     self._nextScanAt = new Date(now.valueOf() + self._processEvery);
-    self._findAndLockNextJob(name, definitions[name], function (err, job) {
+    self._findAndLockNextJob(name, definitions[name], function(err, jobs) {
       if (err) {
         throw err;
       }
 
-      if (job) {
-        if( Array.isArray(job) ) {
-          jobQueue = job.concat(jobQueue);
-        } else {
-          jobQueue.unshift(job);
+      if (jobs) {
+        if (!Array.isArray(jobs)) {
+          jobs = [jobs]
+        }
+
+        for (job in jobs) {
+          job = jobs[job];
+
+          var job_index = 0;
+
+          // iterate the jobQueue to see at which index the job should be spliced in at based on priority
+          for (queued_job in jobQueue) {
+            queued_job = jobQueue[queued_job];
+
+            if (queued_job.attrs.priority < job.attrs.priority) {
+              job_index++;
+            }
+          }
+
+          // insert the job to the queue at its prioritized position for processing
+          jobQueue.splice(job_index, 0, job);
         }
 
         jobQueueFilling(name);

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -96,7 +96,7 @@ Agenda.prototype.database = function(url, collection, options, cb) {
  */
 Agenda.prototype.db_init = function( collection ){
   this._collection = this._mdb.collection(collection || 'agendaJobs');
-  /*this._collection.createIndexes([{
+  this._collection.createIndexes([{
                                   "key": {"name" : 1, "priority" : -1, "lockedAt" : 1, "nextRunAt" : 1, "disabled" : 1},
                                   "name": "findAndLockNextJobIndex1"
                                 }, {
@@ -105,7 +105,7 @@ Agenda.prototype.db_init = function( collection ){
                                 }],
                                 function( err, result ){
                                   if (err) throw err;
-                                });*/
+                                });
 };
 
 Agenda.prototype.name = function(name) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgraded-agenda",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
-  "name": "upgraded-agenda",
-  "version": "0.7.5",
+  "name": "agenda",
+  "version": "0.7.2",
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "blanket": {
+      "pattern": "lib",
+      "data-cover-never": "node_modules"
+    }
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/CamHenlin/agenda"
+    "url": "git://github.com/classdojo/agenda"
   },
   "keywords": [
     "job",
@@ -36,9 +40,5 @@
     "mocha": "~2.3.2",
     "mocha-lcov-reporter": "0.0.2",
     "q": "~1.4.1"
-  },
-  "homepage": "https://github.com/classdojo/agenda",
-  "directories": {
-    "test": "test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,18 +1,14 @@
 {
-  "name": "agenda",
-  "version": "0.7.2",
+  "name": "upgraded-agenda",
+  "version": "0.7.4",
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
-    "blanket": {
-      "pattern": "lib",
-      "data-cover-never": "node_modules"
-    }
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/classdojo/agenda"
+    "url": "git://github.com/CamHenlin/agenda"
   },
   "keywords": [
     "job",
@@ -40,5 +36,9 @@
     "mocha": "~2.3.2",
     "mocha-lcov-reporter": "0.0.2",
     "q": "~1.4.1"
+  },
+  "homepage": "https://github.com/classdojo/agenda",
+  "directories": {
+    "test": "test"
   }
 }


### PR DESCRIPTION
This modification makes jobQueueFilling search the jobQueue for insertion index based on priority rather than simply unshifting jobs into the jobQueue. This allows jobs with a higher priority to run before jobs that already exist in the queue but are not yet running.