### PR TITLE
Add option to unique that prevents update to job when already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,9 +547,14 @@ job.priority('low');
 job.save();
 ```
 
-### unique(properties)
+### unique(properties, [options])
 
 Ensure that only one instance of this job exists with the specified properties
+
+`options` is an optional argument which can overwrite the defaults. It can take
+the following:
+
+- `insertOnly`: `boolean` will prevent any properties from persisting if job already exists. Defaults to false.
 
 ```js
 job.unique({'data.type': 'active', 'data.userId': '123', nextRunAt(date)});

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -252,9 +252,11 @@ Agenda.prototype.saveJob = function(job, cb) {
   var props = job.toJSON();
   var id = job.attrs._id;
   var unique = job.attrs.unique;
+  var uniqueOpts = job.attrs.uniqueOpts;
 
   delete props._id;
   delete props.unique;
+  delete props.uniqueOpts;
 
   props.lastModifiedBy = this._name;
 
@@ -278,6 +280,8 @@ Agenda.prototype.saveJob = function(job, cb) {
   } else if (unique) {
     var query = job.attrs.unique;
     query.name = props.name;
+    if( uniqueOpts && uniqueOpts.insertOnly )
+      update = { $setOnInsert: props };
     this._collection.findAndModify(query, {}, update, {upsert: true, new: true}, processDbResult);
   } else {
     this._collection.insertOne(props, processDbResult);    // NF updated 22/04/2015

--- a/lib/job.js
+++ b/lib/job.js
@@ -131,8 +131,9 @@ Job.prototype.enable = function() {
   return this;
 };
 
-Job.prototype.unique = function(unique) {
+Job.prototype.unique = function(unique, opts) {
   this.attrs.unique = unique;
+  this.attrs.uniqueOpts = opts;
   return this;
 };
 

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -247,10 +247,10 @@ describe("agenda", function() {
 
         describe('should demonstrate unique contraint', function(done) {
 
-          it('should create one job when unique matches', function(done) {
-            var time = new Date();
-            jobs.create('unique job', {type: 'active', userId: '123', 'other': true}).unique({'data.type': 'active', 'data.userId': '123', nextRunAt: time}).schedule(time).save(function(err, job) {
-             jobs.create('unique job', {type: 'active', userId: '123', 'other': false}).unique({'data.type': 'active', 'data.userId': '123', nextRunAt: time}).schedule(time).save(function(err, job) {
+          it('should modify one job when unique matches', function(done) {
+            jobs.create('unique job', {type: 'active', userId: '123', 'other': true}).unique({'data.type': 'active', 'data.userId': '123'}).schedule("now").save(function(err, job1) {
+             jobs.create('unique job', {type: 'active', userId: '123', 'other': false}).unique({'data.type': 'active', 'data.userId': '123'}).schedule("now").save(function(err, job2) {
+               expect(job1.attrs.nextRunAt.toISOString()).not.to.equal(job2.attrs.nextRunAt.toISOString())
                 mongo.collection('agendaJobs').find({name: 'unique job'}).toArray(function(err, j) {
                   expect(j).to.have.length(1);
                   done();
@@ -258,6 +258,19 @@ describe("agenda", function() {
              });
             });
           });
+
+          it('should not modify job when unique matches and insertOnly is set to true', function(done) {
+            jobs.create('unique job', {type: 'active', userId: '123', 'other': true}).unique({'data.type': 'active', 'data.userId': '123'}, { insertOnly: true }).schedule("now").save(function(err, job1) {
+              jobs.create('unique job', {type: 'active', userId: '123', 'other': false}).unique({'data.type': 'active', 'data.userId': '123'}, {insertOnly: true}).schedule("now").save(function(err, job2) {
+                expect(job1.attrs.nextRunAt.toISOString()).to.equal(job2.attrs.nextRunAt.toISOString())
+                mongo.collection('agendaJobs').find({name: 'unique job'}).toArray(function(err, j) {
+                  expect(j).to.have.length(1);
+                  done();
+                });
+              });
+            });
+          });
+
           after(clearJobs);
 
         });


### PR DESCRIPTION
Adds ability to set `insertOnly` to `.unique` that uses setOnInsert instead of set for properties.
#226 