### PR TITLE
Added A Fix To Stop Concurrent Jobs Executing Out Of Sequence

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -262,7 +262,6 @@ Agenda.prototype.saveJob = function(job, cb) {
       protect = {},
       update = { $set: props };
 
-
   if (id) {
     this._collection.findAndModify({_id: id}, {}, update, {new: true}, processDbResult );
   } else if (props.type == 'single') {
@@ -457,9 +456,16 @@ function processJobs(extraJob) {
         if (jobDefinition.concurrency > jobDefinition.running &&
             self._runningJobs.length < self._maxConcurrency) {
 
+          if(jobDefinition._lastCompletedJob){
+            //If The Next Run Time At Is Less Than The Last Completed Jobs Next Run, Then Don't Run It Again.
+            if(job.attrs.nextRunAt < jobDefinition._lastCompletedJob.attrs.nextRunAt){
+              jobProcessing();
+              return;
+            }
+          }
+
           self._runningJobs.push(job);
           jobDefinition.running++;
-
           job.run(processJobResult);
           jobProcessing();
         } else {
@@ -475,6 +481,9 @@ function processJobs(extraJob) {
 
     self._runningJobs.splice(self._runningJobs.indexOf(job), 1);
     definitions[name].running--;
+
+    //Assigning the last completed job for a specific job.
+    definitions[name]._lastCompletedJob = job;
 
     jobProcessing();
   }

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -424,6 +424,66 @@ describe("agenda", function() {
     });
   });
 
+  describe('Scheduling Concurrent Jobs', function() {
+
+    beforeEach(function(done) {
+      clearJobs(done);
+    });
+    after(clearJobs);
+
+    it('do not run more than once in a scheduled time interval', function(done) {
+      var jobs = new Agenda({
+        defaultConcurrency: 1,
+        db: {
+          address: mongoCfg
+        }
+      });
+      var jobRunInterval = 400;
+      var jobRunTime = 200;
+      var processEvery = 300;
+      var successTime = 5000;
+      var lastRunAt;
+
+      function jobProcessor(job, done){
+        if(lastRunAt){
+          var timeSinceLastRun = new Date() - lastRunAt;
+
+          if(timeSinceLastRun < jobRunInterval - 50 || timeSinceLastRun > jobRunInterval + 50){
+            throw "INVALID Job Execution Time " + timeSinceLastRun;
+          }
+        }
+
+        lastRunAt = new Date();
+
+        setTimeout(function(){
+          done();
+        }, jobRunTime);
+      }
+
+
+      jobs.define('concjob', {concurrency: 1}, jobProcessor);
+      var interval = setInterval(function(){
+        clearInterval(interval);
+        jobs.stop(done);
+      }, successTime);
+
+      jobs.on('fail', function(err){
+        clearInterval(interval);
+        jobs.stop(function(){
+          done(err);
+        });
+      });
+
+      this.timeout(11000);
+
+      jobs.on('ready', function(){
+        jobs.every( jobRunInterval, 'concjob' );
+        jobs.processEvery(processEvery);
+        jobs.start();
+      });
+    });
+  });
+
   describe('Job', function() {
     describe('repeatAt', function() {
       var job = new Job();


### PR DESCRIPTION
Related to: https://github.com/rschmukler/agenda/issues/231

When using a concurrency of 1, it was possible for jobs to execute out of sequence.

A Job in memory with a `nextRunAt` time less than the `nextRunAt` time of a job loaded from the database would execute immediately causing a Job to run between intervals.

The test in this PR highlights the issue. The fix has not broken any existing tests.

This will fix the bug on the master branch. If possible can you also apply the patch to version 0.6.28 and publish as 0.6.29 as I am using MongoDB 2.4.

I have the patch at https://github.com/rschmukler/agenda/compare/0.6.28...nialldonnellyfh:fix_concurrency_bug

Kind Regards
Niall Donnelly