### PR TITLE
Improve job failure handling

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -51,6 +51,7 @@ var Agenda = module.exports = function(config, cb) {
   } else if (config.mongo) {
     this._mdb = config.mongo;
     this.db_init( config.db ? config.db.collection : undefined );    // NF 20/04/2015
+    this.emit('ready');
   }
 };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -152,6 +152,7 @@ Job.prototype.fail = function(reason) {
     reason = reason.message;
   }
   this.attrs.failReason = reason;
+  this.attrs.failCount = (this.attrs.failCount || 0) + 1;
   this.attrs.failedAt = new Date();
   return this;
 };
@@ -169,17 +170,19 @@ Job.prototype.run = function(cb) {
       var jobCallback = function(err) {
         if (err) {
           self.fail(err);
-          agenda.emit('fail', err, self);
-          agenda.emit('fail:' + self.attrs.name, err, self);
-        } else {
-          agenda.emit('success', self);
-          agenda.emit('success:' + self.attrs.name, self);
         }
 
         self.attrs.lastFinishedAt = new Date();
         self.attrs.lockedAt = null;
         self.save(function(saveErr, job) {
           cb && cb(err || saveErr, job);
+          if (err) {
+            agenda.emit('fail', err, self);
+            agenda.emit('fail:' + self.attrs.name, err, self);
+          } else {
+            agenda.emit('success', self);
+            agenda.emit('success:' + self.attrs.name, self);
+          }
           agenda.emit('complete', self);
           agenda.emit('complete:' + self.attrs.name, self);
         });

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -905,7 +905,15 @@ describe("agenda", function() {
           jobs.once('fail', function(err, j) {
             expect(err.message).to.be('Zomg fail');
             expect(j).to.be(job);
-            done();
+            expect(j.attrs.failCount).to.be(1);
+            expect(j.attrs.failedAt.valueOf()).not.to.be.below(j.attrs.lastFinishedAt.valueOf());
+
+            jobs.once('fail', function(err, j) {
+              expect(j).to.be(job);
+              expect(j.attrs.failCount).to.be(2);
+              done();
+            });
+            job.run();
           });
           job.run();
         });


### PR DESCRIPTION
- Add a `failCount` job property which refers to the number of time a job has failed
- Move down the `fail`/`success` events triggering inside the `save` callback, to be consistent with the `complete` event

The previous changes give the developer correct `failCount`, `failedAt` and `lastFinishedAt` values, and allow:
- Fetching of all the failed jobs using the following mongodb query:
`{failedAt:{$exists: true}, $where:'this.failedAt >= this.lastFinishedAt'}`
- Retrying of failed jobs due to temporary reasons. For example, the following snippet will retry any jobs failed due to timeout or network error, at most 5 times, using an exponential backoff strategy (thanks to https://github.com/tim-kos/node-retry):
```
agenda.on('fail', (err, job) => {
  if (job.attrs.nextRunAt === null) {
    if (/(timeout of \d+ms exceeded|read ECONNRESET|connect ECONNREFUSED)/.test(err.message)) {
      const timeouts = retry.timeouts({ minTimeout: 10000, factor: 10, retries: 5 });
      const timeout = timeouts[job.attrs.failCount - 1];
      if (timeout) {
        job.attrs.nextRunAt = moment().add(timeout, 'milliseconds').toDate();
        job.save();
      }
    }
  }
});
```