### PR TITLE
Fix agenda throwing an exception when starting a job defined on another instance

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -442,7 +442,7 @@ function processJobs(extraJob) {
     for (jobName in definitions) {
       jobQueueFilling(jobName);
     }
-  } else {
+  } else if (definitions[extraJob.attrs.name]) {
     // On the fly lock a job
     var now = new Date();
     self._collection.findAndModify({ _id: extraJob.attrs._id, lockedAt: null, disabled: { $ne: true } }, {}, { $set: { lockedAt: now } }, function(err, resp) {

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -893,6 +893,19 @@ describe("agenda", function() {
         });
       });
 
+      it('does not throw an error trying to process undefined jobs', function(done) {
+        jobs.start();
+        var job = jobs.create('jobDefinedOnAnotherServer').schedule('now');
+
+        job.save(function(err) {
+          expect(err).to.be(null);
+        });
+
+        setTimeout(function() {
+          jobs.stop(done);
+        }, jobTimeout);
+      });
+
       it('clears locks on stop', function(done) {
         jobs.define('longRunningJob', function(job, cb) {
           //Job never finishes


### PR DESCRIPTION
Starting from server A a job (using `agenda.now` for instance) defined on server B is throwing an error right now: the `saveJob`method is calling `processJobs` with the job passed as `extraJob` parameter, there is no check that this job is defined before locking and requesting its execution.