### PR TITLE
do not block normal jobs from running concurrently

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -513,11 +513,11 @@ function processJobs(extraJob) {
     function runOrRetry() {
       if (self._processInterval) {
         if (jobDefinition.concurrency > jobDefinition.running &&
-            self._runningJobs.length < self._maxConcurrency) {
+          self._runningJobs.length < self._maxConcurrency) {
 
-          if(jobDefinition._lastCompletedJob){
-            //If The Next Run Time At Is Less Than The Last Completed Jobs Next Run, Then Don't Run It Again.
-            if(job.attrs.nextRunAt < jobDefinition._lastCompletedJob.attrs.nextRunAt){
+          if (job.attrs.type === 'single' && jobDefinition._lastCompletedJob) {
+            // If The Next Run Time At Is Less Than The Last Completed Jobs Next Run, Then Don't Run It Again.
+            if (job.attrs.nextRunAt < jobDefinition._lastCompletedJob.attrs.nextRunAt) {
               jobProcessing();
               return;
             }


### PR DESCRIPTION
This is a fix for a problem that was introduced with #250 which is preventing normal jobs from running concurrently. Without this, normal (not single) jobs with the same name can get "stuck" and never run. All I did was require the job type to be single before checking to see if it should be skipped. All tests still pass.