### PR TITLE
Expired jobs

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -515,12 +515,11 @@ function processJobs(extraJob) {
         if (jobDefinition.concurrency > jobDefinition.running &&
           self._runningJobs.length < self._maxConcurrency) {
 
-          if (job.attrs.type === 'single' && jobDefinition._lastCompletedJob) {
-            // If The Next Run Time At Is Less Than The Last Completed Jobs Next Run, Then Don't Run It Again.
-            if (job.attrs.nextRunAt < jobDefinition._lastCompletedJob.attrs.nextRunAt) {
-              jobProcessing();
-              return;
-            }
+          var lockDeadline = new Date(Date.now() - jobDefinition.lockLifetime);
+
+          if (job.attrs.lockedAt < lockDeadline) {
+            jobProcessing();
+            return;
           }
 
           self._runningJobs.push(job);
@@ -540,9 +539,6 @@ function processJobs(extraJob) {
 
     self._runningJobs.splice(self._runningJobs.indexOf(job), 1);
     definitions[name].running--;
-
-    //Assigning the last completed job for a specific job.
-    definitions[name]._lastCompletedJob = job;
 
     jobProcessing();
   }


### PR DESCRIPTION
This PR stops Agenda from running jobs that have expired after they were enqueued, but before they actually got a chance to start.

It's easy to recreate this by setting concurrency to 1 and scheduling multiple jobs that take close to their lock lifetimes to complete. Agenda will lock and enqueue all available jobs. Since it could only run 1 at a time and running that 1 job takes a while, the other jobs' locks would expire while waiting in the in-memory queue. Other Agenda instances (or even the current instance) would lock the job and run it.

This PR removes the fix from PR #250. Now that I understand the code better, I don't think it was correct. The fix in this PR is more general and doesn't have the problem I tried to address in PR #258.

This should fix issues #256 and #231.

This PR also includes changes to the tests so that each test uses its own instance of Agenda. Certain tests were randomly failing every time I ran the whole suite. I was eventually able to tell that jobs from previous tests were raising events after the next test started, confusing the next test with unexpected events. Using a new instance of Agenda makes the tests run slower, but I think the consistency is worth it.