### PR TITLE
Fixing bug where on-the-fly-locked jobs will not run

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -445,9 +445,9 @@ function processJobs(extraJob) {
   } else if (definitions[extraJob.attrs.name]) {
     // On the fly lock a job
     var now = new Date();
-    self._collection.findAndModify({ _id: extraJob.attrs._id, lockedAt: null, disabled: { $ne: true } }, {}, { $set: { lockedAt: now } }, function(err, resp) {
+    self._collection.findAndModify({ _id: extraJob.attrs._id, lockedAt: null, disabled: { $ne: true } }, {}, { $set: { lockedAt: now } }, { new: true }, function(err, resp) {
       if ( resp.value ){    // NF 20/04/2015
-        enqueueJobs(extraJob);
+        enqueueJobs(createJob(self, resp.value));
         jobProcessing();
       }
     });


### PR DESCRIPTION
During the on the fly lock of a job, `extraJob` was being queued without it's updated `lockedAt` time which resulted in the job being queued with a null lock time. Now that `lockedAt` is being used to determine the freshness of the job (from https://github.com/rschmukler/agenda/pull/260), this is a problem. When the run is attempted, the null locked time fails the expiry check, and the job is not run (but remains locked in the database). Using the updated job document after locking solves the problem.