### PR TITLE
Adding repeatTimezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ agenda.define('delete old users', function(job, done) {
 
 agenda.on('ready', function() {
   agenda.every('3 minutes', 'delete old users');
-  
+
   // Alternatively, you could also do:
   agenda.every('*/3 * * * *', 'delete old users');
 
@@ -328,9 +328,9 @@ agenda.define('say hello', function(job) {
 
 ## Creating Jobs
 
-### every(interval, name, [data], [cb])
+### every(interval, name, [data, [options]], [cb])
 
-Runs job `name` at the given `interval`. Optionally, data can be passed in.
+Runs job `name` at the given `interval`. Optionally, data and options can be passed in.
 Every creates a job of type `single`, which means that it will only create one
 job in the database, even if that line is run multiple times. This lets you put
 it in a file that may get run multiple times, such as `webserver.js` which may
@@ -340,6 +340,9 @@ reboot from time to time.
 
 `data` is an optional argument that will be passed to the processing function
 under `job.attrs.data`.
+
+`options` is an optional argument that will be passed to `job.repeatEvery`. In order to use
+this argument, `data` must also be specified.
 
 `cb` is an optional callback function which will be called when the job has been
 persisted in the database.
@@ -518,14 +521,25 @@ A job instance has many instance methods. All mutating methods must be followed
 with a call to `job.save()` in order to persist the changes to the database.
 
 
-### repeatEvery(interval)
+### repeatEvery(interval, [options])
 
 Specifies an `interval` on which the job should repeat.
 
 `interval` can be a human-readable format `String`, a cron format `String`, or a `Number`.
 
+`options` is an optional argument that can include a `timezone` field. The timezone should
+be a string as accepted by [moment-timezone](http://momentjs.com/timezone/) and is considered
+when using an interval in the cron string format.
+
 ```js
 job.repeatEvery('10 minutes');
+job.save();
+```
+
+```js
+job.repeatEvery('0 6 * * *', {
+  timezone: 'America/New_York'
+});
 job.save();
 ```
 

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -168,35 +168,38 @@ Agenda.prototype.define = function(name, options, processor) {
   };
 };
 
-Agenda.prototype.every = function(interval, names, data, cb) {
+Agenda.prototype.every = function(interval, names, data, options, cb) {
   var self = this;
 
   if (cb == undefined && typeof data == 'function') {
     cb = data;
     data = undefined;
+  } else if (cb == undefined && typeof options == 'function') {
+    cb = options;
+    options = undefined;
   }
 
   if (typeof names === 'string' || names instanceof String) {
-    return createJob(interval, names, data, cb);
+    return createJob(interval, names, data, options, cb);
   } else if (Array.isArray(names)) {
-    return createJobs(interval, names, data, cb);
+    return createJobs(interval, names, data, options, cb);
   }
 
-  function createJob(interval, name, data, cb) {
+  function createJob(interval, name, data, options, cb) {
     var job = self.create(name, data);
     job.attrs.type = 'single';
-    job.repeatEvery(interval);
+    job.repeatEvery(interval, options);
     job.computeNextRunAt();
     job.save(cb);
     return job;
   }
 
-  function createJobs(interval, names, data, cb) {
+  function createJobs(interval, names, data, options, cb) {
     var results = [];
     var pending = names.length;
     var errored = false;
     return names.map(function (name, i) {
-      return createJob(interval, name, data, function(err, result) {
+      return createJob(interval, name, data, options, function(err, result) {
         if (err) {
           if (!errored) cb(err);
           errored = true;

--- a/lib/job.js
+++ b/lib/job.js
@@ -115,12 +115,9 @@ Job.prototype.computeNextRunAt = function() {
 };
 
 Job.prototype.repeatEvery = function(interval, options) {
+  options = options || {};
   this.attrs.repeatInterval = interval;
-  if(options && options.timezone) {
-    this.attrs.repeatTimezone = options.timezone;
-  } else {
-    delete this.attrs.repeatTimezone;
-  }
+  this.attrs.repeatTimezone = options.timezone ? options.timezone : null;
   return this;
 };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -9,7 +9,8 @@
 
 var humanInterval = require('human-interval'),
     CronTime = require('cron').CronTime,
-    date = require('date.js');
+    date = require('date.js'),
+    moment = require('moment-timezone');
 
 var Job = module.exports = function Job(args) {
   args = args || {};
@@ -59,6 +60,7 @@ Job.prototype.toJSON = function() { // create a persistable Mongo object -RR
 
 Job.prototype.computeNextRunAt = function() {
   var interval = this.attrs.repeatInterval;
+  var timezone = this.attrs.repeatTimezone;
   var repeatAt = this.attrs.repeatAt;
   this.attrs.nextRunAt = undefined;
 
@@ -71,6 +73,7 @@ Job.prototype.computeNextRunAt = function() {
 
   function computeFromInterval() {
     var lastRun = this.attrs.lastRunAt || new Date();
+    if(timezone) lastRun = moment(lastRun).tz(timezone);
     try {
       var cronTime = new CronTime(interval);
       var nextDate = cronTime._getNextDateFrom(lastRun);
@@ -111,8 +114,13 @@ Job.prototype.computeNextRunAt = function() {
   }
 };
 
-Job.prototype.repeatEvery = function(interval) {
+Job.prototype.repeatEvery = function(interval, options) {
   this.attrs.repeatInterval = interval;
+  if(options && options.timezone) {
+    this.attrs.repeatTimezone = options.timezone;
+  } else {
+    delete this.attrs.repeatTimezone;
+  }
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "url": "https://github.com/rschmukler/agenda/issues"
   },
   "dependencies": {
-    "human-interval": "~0.1.3",
+    "cron": "~1.0.1",
     "date.js": "~0.2.0",
-    "mongodb": "2.0.34",
-    "cron": "~1.0.1"
+    "human-interval": "~0.1.3",
+    "moment-timezone": "^0.5.0",
+    "mongodb": "2.0.34"
   },
   "devDependencies": {
     "blanket": "1.1.5",

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -5,6 +5,7 @@ var mongoHost = process.env.MONGODB_HOST || 'localhost',
 
 var expect = require('expect.js'),
     path = require('path'),
+    moment = require('moment-timezone'),
     cp = require('child_process'),
     Agenda = require( path.join('..', 'index.js') ),
     Job = require( path.join('..', 'lib', 'job.js') );
@@ -551,6 +552,21 @@ describe("agenda", function() {
         job.repeatEvery('*/2 * * * *');
         job.computeNextRunAt();
         expect(job.attrs.nextRunAt.valueOf()).to.be(now.valueOf() + 60000);
+      });
+
+      it('understands cron intervals with a timezone', function () {
+        var date = moment()
+          .tz('GMT')
+          .hours(6)
+          .minutes(1)
+          .toDate();
+        job.attrs.lastRunAt = date;
+        job.repeatEvery('0 6 * * *', {
+          timezone: 'GMT'
+        });
+        job.computeNextRunAt();
+        expect(moment(job.attrs.nextRunAt).tz('GMT').hour()).to.be(6);
+        expect(moment(job.attrs.nextRunAt).toDate().getDate()).to.be(moment(job.attrs.lastRunAt).add(1, 'days').toDate().getDate());
       });
 
       describe('when repeat at time is invalid', function () {


### PR DESCRIPTION
This feature allows `options` to be passed to `agenda.every()` and `job.repeatEvery()`. Currently, the only property of `options` is `timezone` which is used in conjunction with a cron string interval to determine the correct nextRunAt for the specified timezone.

for #79 