### PR TITLE
Fixing computeNextRunAt timezone bug.

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -71,15 +71,21 @@ Job.prototype.computeNextRunAt = function() {
   }
   return this;
 
+  function dateForTimezone (d) {
+    d = moment(d);
+    if(timezone) d.tz(timezone);
+    return d;
+  }
+
   function computeFromInterval() {
     var lastRun = this.attrs.lastRunAt || new Date();
-    if(timezone) lastRun = moment(lastRun).tz(timezone);
+    lastRun = dateForTimezone(lastRun);
     try {
       var cronTime = new CronTime(interval);
       var nextDate = cronTime._getNextDateFrom(lastRun);
       if (nextDate.valueOf() == lastRun.valueOf()) {
         // Handle cronTime giving back the same date for the next run time
-        nextDate = cronTime._getNextDateFrom(new Date(lastRun.valueOf() + 1000));
+        nextDate = cronTime._getNextDateFrom(dateForTimezone(new Date(lastRun.valueOf() + 1000)));
       }
       this.attrs.nextRunAt = nextDate;
     } catch (e) {

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -558,11 +558,18 @@ describe("agenda", function() {
       });
 
       it('understands cron intervals with a timezone', function () {
-        var date = moment()
-          .tz('GMT')
-          .hours(6)
-          .minutes(1)
-          .toDate();
+        var date = new Date('2015-01-01T06:01:00-00:00');
+        job.attrs.lastRunAt = date;
+        job.repeatEvery('0 6 * * *', {
+          timezone: 'GMT'
+        });
+        job.computeNextRunAt();
+        expect(moment(job.attrs.nextRunAt).tz('GMT').hour()).to.be(6);
+        expect(moment(job.attrs.nextRunAt).toDate().getDate()).to.be(moment(job.attrs.lastRunAt).add(1, 'days').toDate().getDate());
+      });
+
+      it('understands cron intervals with a timezone when last run is the same as the interval', function () {
+        var date = new Date('2015-01-01T06:00:00-00:00');
         job.attrs.lastRunAt = date;
         job.repeatEvery('0 6 * * *', {
           timezone: 'GMT'


### PR DESCRIPTION
I noticed that my jobs scheduled with a repeatTimezone were getting scheduled for the wrong time. The issue was occurring in `Job.computeNextRunAt()`. If `cronTime._getNextDateFrom(lastRun)` returns the same date, `lastRun` is adjusted by adding 1 second and nextDate is recalculated. The date used to recalculate was not considering timezone resulting in the intermittent error I was seeing.

This PR fixes the issue and includes a test that fails with on the current version.