### PR TITLE
Use callback to handle MongoClient connection errors if we can.

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -68,8 +68,18 @@ Agenda.prototype.database = function(url, collection, options, cb) {
   collection = collection || 'agendaJobs';
   options = options || {};
   var self = this;
-  MongoClient.connect(url, options, function( error, db ){
-    if (error) throw error;   // Auth failed etc.
+
+  MongoClient.connect(url, options, function ( error, db ){
+    if (error) {
+      if (cb) {
+        cb(error, null);
+      } else { 
+        throw error;
+      }
+
+      return;
+    }
+
     self._mdb = db;
     self.db_init( collection, cb );
   });


### PR DESCRIPTION
When using the Agenda constructor or .database, if a connection error occurred there was no way for me to catch the exception.

If a callback was is in, it will utilize that callback to pass back the error, otherwise it will throw like it has always been.