### PR TITLE
Implementing lock limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ var agenda = new Agenda({maxConcurrency: 20});
 
 ### defaultConcurrency(number)
 
-Takes a `number` which specifies the default number of a specific that can be running at
+Takes a `number` which specifies the default number of a specific job that can be running at
 any given moment. By default it is `5`.
 
 ```js
@@ -241,6 +241,34 @@ You can also specify it during instantiation
 
 ```js
 var agenda = new Agenda({defaultConcurrency: 5});
+```
+
+### lockLimit(number)
+
+Takes a `number` shich specifies the max number jobs that can be locked at any given moment. By default it is `0` for no max.
+
+```js
+agenda.lockLimit(0);
+```
+
+You can also specify it during instantiation
+
+```js
+var agenda = new Agenda({lockLimit: 0});
+```
+
+### defaultLockLimit(number)
+
+Takes a `number` which specifies the default number of a specific job that can be locked at any given moment. By default it is `0` for no max.
+
+```js
+agenda.defaultLockLimit(0);
+```
+
+You can also specify it during instantiation
+
+```js
+var agenda = new Agenda({defaultLockLimit: 0});
 ```
 
 ### defaultLockLifetime(number)
@@ -289,7 +317,8 @@ you may omit `done` from the signature.
 `options` is an optional argument which can overwrite the defaults. It can take
 the following:
 
-- `concurrency`: `number` maxinum number of that job that can be running at once (per instance of agenda)
+- `concurrency`: `number` maximum number of that job that can be running at once (per instance of agenda)
+- `lockLimit`: `number` maximum number of that job that can be locked at once (per instance of agenda)
 - `lockLifetime`: `number` interval in ms of how long the job stays locked for (see [multiple job processors](#multiple-job-processors) for more info).
 A job will automatically unlock if `done()` is called.
 - `priority`: `(lowest|low|normal|high|highest|number)` specifies the priority

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -32,10 +32,16 @@ var Agenda = module.exports = function(config, cb) {
   this._processEvery = humanInterval(config.processEvery) || humanInterval('5 seconds');
   this._defaultConcurrency = config.defaultConcurrency || 5;
   this._maxConcurrency = config.maxConcurrency || 20;
+  this._defaultLockLimit = config.defaultLockLimit || 0;
+  this._lockLimit = config.lockLimit || 0;
   this._definitions = {};
   this._runningJobs = [];
+  this._lockedJobs = [];
   this._jobQueue = [];
   this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; //10 minute default lockLifetime
+
+  this._isLockingOnTheFly = false;
+  this._jobsToLock = [];
   if (config.mongo) {
     this.mongo(config.mongo, config.db ? config.db.collection : undefined, cb);
   } else if (config.db) {
@@ -121,6 +127,16 @@ Agenda.prototype.defaultConcurrency = function(num) {
   return this;
 };
 
+Agenda.prototype.lockLimit = function (num) {
+  this._lockLimit = num;
+  return this;
+};
+
+Agenda.prototype.defaultLockLimit = function (num) {
+  this._defaultLockLimit = num;
+  return this;
+};
+
 Agenda.prototype.defaultLockLifetime = function(ms){
   this._defaultLockLifetime = ms;
   return this;
@@ -162,9 +178,11 @@ Agenda.prototype.define = function(name, options, processor) {
   this._definitions[name] = {
     fn: processor,
     concurrency: options.concurrency || this._defaultConcurrency,
+    lockLimit: options.lockLimit || this._defaultLockLimit,
     priority: options.priority || 0,
     lockLifetime: options.lockLifetime || this._defaultLockLifetime,
-    running: 0
+    running: 0,
+    locked: 0
   };
 };
 
@@ -363,7 +381,7 @@ Agenda.prototype.stop = function(cb) {
   cb = cb || function() {};
   clearInterval(this._processInterval);
   this._processInterval = undefined;
-  this._unlockJobs( cb );
+  this._unlockJobs(cb);
 };
 
 /**
@@ -380,8 +398,8 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
 
   // Don't try and access Mongo Db if we've lost connection to it. Also see clibu_automation.js db.on.close code. NF 29/04/2015
   // Trying to resolve crash on Dev PC when it resumes from sleep.
-  if ( this._mdb.s.topology.connections().length === 0 ) {
-    cb( new Error( 'No MongoDB Connection') );
+  if (this._mdb.s.topology.connections().length === 0) {
+    cb(new Error( 'No MongoDB Connection'));
   } else {
     this._collection.findAndModify(
       {
@@ -391,15 +409,15 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
           {name: jobName, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }}
         ]
       },
-      {'priority': -1},     // sort
-      {$set: {lockedAt: now}},   // Doc
-      {'new': true},          // options
-      function( error, result ){
-          var jobs;
-          if ( !error && result.value ){
-              jobs = createJob( self, result.value );
-          }
-          cb( error, jobs );
+      {'priority': -1},  // sort
+      {$set: {lockedAt: now}},  // Doc
+      {'new': true},  // options
+      function (err, result) {
+        var job;
+        if (!err && result.value) {
+          job = createJob(self, result.value);
+        }
+        cb(err, job);
       }
     );
   }
@@ -421,15 +439,11 @@ function createJob(agenda, jobData) {
 // Refactored to Agenda method. NF 22/04/2015
 // @caller Agenda.stop() only. Could be moved into stop(). NF
 Agenda.prototype._unlockJobs = function(done) {
-  function getJobId(j) {
-    return j.attrs._id;
-  }
-
-  var jobIds = this._jobQueue.map(getJobId)
-       .concat(this._runningJobs.map(getJobId));
+  var jobIds = this._lockedJobs.map(function (job) {
+    return job.attrs._id;
+  });
   this._collection.updateMany({_id: { $in: jobIds } }, { $set: { lockedAt: null } }, done);    // NF refactored .update() 22/04/2015
 };
-
 
 function processJobs(extraJob) {
   if (!this._processInterval) {
@@ -446,14 +460,29 @@ function processJobs(extraJob) {
       jobQueueFilling(jobName);
     }
   } else if (definitions[extraJob.attrs.name]) {
-    // On the fly lock a job
-    var now = new Date();
-    self._collection.findAndModify({ _id: extraJob.attrs._id, lockedAt: null, disabled: { $ne: true } }, {}, { $set: { lockedAt: now } }, { new: true }, function(err, resp) {
-      if ( resp.value ){    // NF 20/04/2015
-        enqueueJobs(createJob(self, resp.value));
-        jobProcessing();
-      }
-    });
+    self._jobsToLock.push(extraJob);
+    lockOnTheFly();
+  }
+
+   /**
+    * Returns true if a job of the specified name can be locked.
+    *
+    * Considers maximum locked jobs at any time if self._lockLimit is > 0
+    * Considers maximum locked jobs of the specified name at any time if jobDefinition.lockLimit is > 0
+    */
+  function shouldLock(name) {
+    var shouldLock = true;
+    var jobDefinition = definitions[name];
+
+    if(self._lockLimit && self._lockLimit <= self._lockedJobs.length) {
+      shouldLock = false;
+    }
+
+    if(jobDefinition.lockLimit && jobDefinition.lockLimit <= jobDefinition.locked) {
+      shouldLock = false;
+    }
+
+    return shouldLock;
   }
 
   function enqueueJobs(jobs) {
@@ -476,16 +505,61 @@ function processJobs(extraJob) {
     });
   }
 
+  function lockOnTheFly() {
+    if(self._isLockingOnTheFly) {
+      return;
+    }
+
+    if(!self._jobsToLock.length) {
+      self._isLockingOnTheFly = false;
+      return;
+    }
+
+    self._isLockingOnTheFly = true;
+
+    var now = new Date();
+    var job = self._jobsToLock.pop();
+
+    // If locking limits have been hit, stop locking on the fly.
+    // Jobs that were waiting to be locked will be picked up during a
+    // future locking interval.
+    if(!shouldLock(job.attrs.name)) {
+      self._jobsToLock = [];
+      self._isLockingOnTheFly = false;
+      return;
+    }
+
+    self._collection.findAndModify({ _id: job.attrs._id, lockedAt: null, disabled: { $ne: true } }, {}, { $set: { lockedAt: now } }, { new: true }, function(err, resp) {
+      if (resp.value) {
+        var job = createJob(self, resp.value);
+
+        self._lockedJobs.push(job);
+        definitions[job.attrs.name].locked++;
+
+        enqueueJobs(job);
+        jobProcessing();
+      }
+      lockOnTheFly();
+    });
+  }
+
   function jobQueueFilling(name) {
+    if(!shouldLock(name)) {
+      return;
+    }
+
     var now = new Date();
     self._nextScanAt = new Date(now.valueOf() + self._processEvery);
-    self._findAndLockNextJob(name, definitions[name], function(err, jobs) {
+    self._findAndLockNextJob(name, definitions[name], function(err, job) {
       if (err) {
         throw err;
       }
 
-      if (jobs) {
-        enqueueJobs(jobs);
+      if (job) {
+        self._lockedJobs.push(job);
+        definitions[job.attrs.name].locked++;
+
+        enqueueJobs(job);
         jobQueueFilling(name);
         jobProcessing();
       }
@@ -517,6 +591,9 @@ function processJobs(extraJob) {
           var lockDeadline = new Date(Date.now() - jobDefinition.lockLifetime);
 
           if (job.attrs.lockedAt < lockDeadline) {
+            // Drop expired job
+            self._lockedJobs.splice(self._lockedJobs.indexOf(job), 1);
+            jobDefinition.locked--;
             jobProcessing();
             return;
           }
@@ -538,6 +615,9 @@ function processJobs(extraJob) {
 
     self._runningJobs.splice(self._runningJobs.indexOf(job), 1);
     definitions[name].running--;
+
+    self._lockedJobs.splice(self._lockedJobs.indexOf(job), 1);
+    definitions[name].locked--;
 
     jobProcessing();
   }

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -539,6 +539,7 @@ function processJobs(extraJob) {
         enqueueJobs(job);
         jobProcessing();
       }
+      self._isLockingOnTheFly = false;
       lockOnTheFly();
     });
   }


### PR DESCRIPTION
This addresses the issue of multiple machines/processes not sharing locks well described in #256 by providing a `lockLimit` setting. `lockLimit` controls the number of jobs an instance of agenda will have locked at any moment. It can also be specified on a job definition to control how many of a specific job can be locked at one time.

As part of this change I moved on-the-fly locking into a recursive method that waits for the lock response before attempted the lock of the next one. Previously many on-the-fly locks could be started before any responses were received from the database, making it difficult to control the number of locked jobs without introducing some tricky race conditions.

Some minor formatting changes are also included to bring some newer code in line with the existing code's style.

I also moved the "Locking" test up into the "job lock" test section where it seemed to be a better fit.