### PR TITLE
throw on processJobResult error

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -622,6 +622,7 @@ function processJobs(extraJob) {
   }
 
   function processJobResult(err, job) {
+    if (err) throw(err)
     var name = job.attrs.name;
 
     self._runningJobs.splice(self._runningJobs.indexOf(job), 1);

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -622,7 +622,7 @@ function processJobs(extraJob) {
   }
 
   function processJobResult(err, job) {
-    if (err) throw(err)
+    if (err && !job) throw(err)
     var name = job.attrs.name;
 
     self._runningJobs.splice(self._runningJobs.indexOf(job), 1);


### PR DESCRIPTION
Just a very small thing - this happened to me when the connection to Mongo dropped. Without this, the error I got was:
TypeError: Cannot read property 'attrs' of undefined

rather than:
MongoError: server localhost:27017 sockets closed