### PR TITLE
Picking up any job with an expired lock (not just recurring or queued).

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -416,7 +416,7 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
         $or: [
           {name: jobName, lockedAt: null, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }},
           {name: jobName, lockedAt: {$exists: false}, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }},
-          {name: jobName, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }}
+          {name: jobName, lockedAt: {$lte: lockDeadline}, disabled: { $ne: true }}
         ]
       },
       {'priority': -1},  // sort


### PR DESCRIPTION
fixes #302 

Small change to agenda.js so that running locked jobs will be picked up again if their locks expire. I went ahead with picking up _any_ job with an expired lock. I haven't been able to think of a case where this would cause a problem. If anyone can come up with a case where this could be an issue, post a comment and I will take a look.

I added one test for one-time jobs being picked up after locks expire and I modified another test which didn't make sense anymore (formerly called `'does not process jobs with expired locks'` and now `'does not process locked jobs'`).