### PR TITLE
Add support for `mongoose.connection` for `agenda.mongo()`, fixes #156

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -408,7 +408,8 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
 
   // Don't try and access Mongo Db if we've lost connection to it. Also see clibu_automation.js db.on.close code. NF 29/04/2015
   // Trying to resolve crash on Dev PC when it resumes from sleep.
-  if (this._mdb.s.topology.connections().length === 0) {
+  var s = this._mdb.s || this._mdb.db.s;
+  if (s.topology.connections().length === 0) {
     cb(new Error( 'No MongoDB Connection'));
   } else {
     this._collection.findAndModify(


### PR DESCRIPTION
This PR adds support of `mongoose.connection` as `agenda.mongo()`.

Now you can share your existing mongoose connection with agenda instances, like:

```js
var mongoose = require('mongoose');
var Agenda = require('agenda');

var agenda = new Agenda({ mongo: mongoose.connection });
```