### PR TITLE
Update to mongo driver 2.1.11 and extend mongo compatability to inclu…

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+0.9.0 / 2016-06-07
+==================
+  * Upgrade mongo driver to 2.1.11
+  * Increase Mongo compatability to 2.4
 
 0.8.1 / 2016-05-08
 ==================

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -106,14 +106,32 @@ Agenda.prototype.db_init = function( collection, cb ){
                                   "key": {"name" : 1, "lockedAt" : 1, "priority" : -1, "nextRunAt" : 1, "disabled" : 1},
                                   "name": "findAndLockNextJobIndex2"
                                 }],
-                                function( err, result ){
-                                  if (err) {
-                                    self.emit('error', err);
-                                  } else {
-                                    self.emit('ready');
-                                  }
+                                function (err, result) {
+                                  try {
+                                    if (err) {
+                                      self.emit('error', err);
+                                    } else {
+                                      self.emit('ready');
+                                    }
+                                    if (cb) cb(err, self._collection);
+                                  } catch(e){
+                                    if(e.message === 'no such cmd: createIndexes'){
+                                      // Looks like a 2.4.x database
+                                      self._collection.ensureIndex(
+                                        {"name": 1, "priority": -1, "lockedAt": 1, "nextRunAt": 1, "disabled": 1},
+                                        {name: "findAndLockNextJobIndex1"}
+                                      );
+                                      self._collection.ensureIndex(
+                                        {"name": 1, "lockedAt": 1, "priority": -1, "nextRunAt": 1, "disabled": 1},
+                                        {name: "findAndLockNextJobIndex2"}
+                                      );
+                                      if (cb) cb(err, self._collection);
+                                    } else {
+                                      // actual problem encountered, rethrow the exception
+                                      throw e;
 
-                                  if (cb) cb(err, self._collection);
+                                    }
+                                  }
                                 });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenda",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
   "scripts": {
@@ -32,7 +32,7 @@
     "date.js": "~0.3.1",
     "human-interval": "~0.1.3",
     "moment-timezone": "^0.5.0",
-    "mongodb": "2.0.34"
+    "mongodb": "2.1.11"
   },
   "devDependencies": {
     "blanket": "1.1.5",


### PR DESCRIPTION
## What
- Update agenda to use 2.1.11 of the node.js mongo driver.
- Update agenda to be compatible back as far as mongo 2.4.

## Why
- 2.1.11 of the Mongo driver is the most recent release and compatible upto the latest releases of mongo.
- Mongo 2.4 is still quite widely used and adding support for this version of mongo increases the use-cases for agenda.

## How 
- The upgrade of the mongo driver was simply updating the package.json file, and retesting the package
- Compatability with 2.4 was broken by the call to createIndexes, catching the exception here, and gracefully failing back to ensureIndex which is compatible with 2.4 resolved the issue. 

## Testing
This has been tested against Mongo 2.4 and 3.2, and also tested with node 0.10.x and 4.4.x. The testing was executed using `npm test` in each scenario.