### PR TITLE
Fix for race condition in the afterEach clean up code

### DIFF
--- a/test/agenda.js
+++ b/test/agenda.js
@@ -60,14 +60,15 @@ describe("agenda", function() {
   });
 
   afterEach(function(done) {
-      setTimeout(function() {
+    setTimeout(function() {
+      jobs.stop(function() {
         clearJobs(function() {
-          mongo.close(function () {
-            jobs.stop();
+          mongo.close(function() {
             jobs._mdb.close(done);
           });
         });
-      }, 50);
+      });
+    }, 50);
   });
 
   describe('Agenda', function() {


### PR DESCRIPTION
The race condition would happen after test "job concurrency" -> "should not block a job for concurrency of another job"
The change made it stop processing jobs before disconnecting.