### PR TITLE
incompatible with mongoose objects

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -46,12 +46,28 @@ var Agenda = module.exports = function(config, cb) {
     this.mongo(config.mongo, config.db ? config.db.collection : undefined, cb);
   } else if (config.db) {
     this.database(config.db.address, config.db.collection, config.db.options, cb);
+  } else if (config.mongooseCollection) {
+    this.mongoose(mongooseCollection, cb);
   }
 };
 
 utils.inherits(Agenda, Emitter);    // Job uses emit() to fire job events client can use.
 
 // Configuration Methods
+Agenda.prototype.mongoose = function( mongooseCollection, cb ) {
+  this._collection = mongooseCollection;
+  var self = this;
+  this._collection.createIndexes([{
+                                  "key": {"name" : 1, "priority" : -1, "lockedAt" : 1, "nextRunAt" : 1, "disabled" : 1},
+                                  "name": "findAndLockNextJobIndex1"
+                                }, {
+                                  "key": {"name" : 1, "lockedAt" : 1, "priority" : -1, "nextRunAt" : 1, "disabled" : 1},
+                                  "name": "findAndLockNextJobIndex2"
+                                }],
+                                function( err, result ){
+                                  handleLegacyCreateIndex(err, result, self, cb)
+                                });
+};
 
 Agenda.prototype.mongo = function( mdb, collection, cb ){
   this._mdb = mdb;

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -46,28 +46,10 @@ var Agenda = module.exports = function(config, cb) {
     this.mongo(config.mongo, config.db ? config.db.collection : undefined, cb);
   } else if (config.db) {
     this.database(config.db.address, config.db.collection, config.db.options, cb);
-  } else if (config.mongooseCollection) {
-    this.mongoose(config.mongooseCollection, cb);
   }
 };
 
 utils.inherits(Agenda, Emitter);    // Job uses emit() to fire job events client can use.
-
-// Configuration Methods
-Agenda.prototype.mongoose = function( mongooseCollection, cb ) {
-  this._collection = mongooseCollection;
-  var self = this;
-  this._collection.createIndexes([{
-                                  "key": {"name" : 1, "priority" : -1, "lockedAt" : 1, "nextRunAt" : 1, "disabled" : 1},
-                                  "name": "findAndLockNextJobIndex1"
-                                }, {
-                                  "key": {"name" : 1, "lockedAt" : 1, "priority" : -1, "nextRunAt" : 1, "disabled" : 1},
-                                  "name": "findAndLockNextJobIndex2"
-                                }],
-                                function( err, result ){
-                                  handleLegacyCreateIndex(err, result, self, cb)
-                                });
-};
 
 Agenda.prototype.mongo = function( mdb, collection, cb ){
   this._mdb = mdb;
@@ -439,7 +421,8 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
 
   // Don't try and access Mongo Db if we've lost connection to it. Also see clibu_automation.js db.on.close code. NF 29/04/2015
   // Trying to resolve crash on Dev PC when it resumes from sleep.
-  if (this._mdb && this._mdb.s.topology.connections().length === 0) {
+  var s = this._mdb?(this._mdb.s || this._mdb.db.s):false;
+  if (s && s.topology.connections().length === 0) {
     cb(new Error( 'No MongoDB Connection'));
   } else {
     this._collection.findAndModify(

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -439,7 +439,7 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
 
   // Don't try and access Mongo Db if we've lost connection to it. Also see clibu_automation.js db.on.close code. NF 29/04/2015
   // Trying to resolve crash on Dev PC when it resumes from sleep.
-  if (this._mdb.s.topology.connections().length === 0) {
+  if (this._mdb && this._mdb.s.topology.connections().length === 0) {
     cb(new Error( 'No MongoDB Connection'));
   } else {
     this._collection.findAndModify(

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -47,7 +47,7 @@ var Agenda = module.exports = function(config, cb) {
   } else if (config.db) {
     this.database(config.db.address, config.db.collection, config.db.options, cb);
   } else if (config.mongooseCollection) {
-    this.mongoose(mongooseCollection, cb);
+    this.mongoose(config.mongooseCollection, cb);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "date.js": "~0.3.1",
     "human-interval": "~0.1.3",
     "moment-timezone": "^0.5.0",
-    "mongodb": "2.1.11"
+    "mongodb": "2.2.9"
   },
   "devDependencies": {
     "blanket": "1.1.5",


### PR DESCRIPTION
newest mongoose uses bson 0.5.x which is not compatibile with bson…… 0.4.x it seems (old driver uses 0.4.x)

errors like this:
Stack: TypeError: Argument must be a string<br at TypeError (native) at Buffer.write (buffer.js:575:21) at serializeObjectId (/home/vcap/app/node_modules/agenda/node_modules/mongodb/node_modules/mongodb-core/node_modules/bson/lib/bson/parser/serializer.js:242:10) at serializeInto (/home/vcap/app/node_modules/agenda/node_modules/mongodb/node_modules/mongodb-core/node_modules/bson/lib/bson/parser/serializer.js:699:17) at serializeObject (/home/vcap/app/node_modules/