### PR TITLE
Added documentation for job.disable() and job.enable()

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,14 @@ job.remove(function(err) {
 })
 ```
 
+### disable()
+
+Disables the `job`. Upcoming runs won't execute.
+
+### enable()
+
+Enables the `job` if it got disabled before. Upcoming runs will execute.
+
 ### touch(callback)
 
 Resets the lock on the job. Useful to indicate that the job hasn't timed out


### PR DESCRIPTION
I added documentation about job.disable() and job.enable() to README.md. I wasn't able to find this information until I investigated the code, so I guess this may be handy for other users too.