### PR TITLE
Bump mongodb dep version to support ssl conns

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "date.js": "~0.3.1",
     "human-interval": "~0.1.3",
     "moment-timezone": "^0.5.0",
-    "mongodb": "2.1.11"
+    "mongodb": "^2.2.10"
   },
   "devDependencies": {
     "blanket": "1.1.5",


### PR DESCRIPTION
As described in https://github.com/rschmukler/agenda/issues/359, using a 2.1.x version does not allow ssl connections to mongodb.

This PR bumps the dependency to a version that supports ssl. It also follows semver `^` to allow further dependency version upgrades without modifying `package.json`.

Test are passing locally with node 6.6.0.