### PR TITLE
Fixes + protects against concurrency not being honored 

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -675,11 +675,13 @@ function processJobs(extraJob) {
     if (err && !job) throw(err)
     var name = job.attrs.name;
 
+    if (self._runningJobs.indexOf(job) == -1) throw("callback already called - job already marked complete");
+
     self._runningJobs.splice(self._runningJobs.indexOf(job), 1);
-    definitions[name].running--;
+    if (definitions[name].running > 0) definitions[name].running--;
 
     self._lockedJobs.splice(self._lockedJobs.indexOf(job), 1);
-    definitions[name].locked--;
+    if (definitions[name].locked > 0) definitions[name].locked--;
 
     jobProcessing();
   }

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -675,7 +675,7 @@ function processJobs(extraJob) {
     if (err && !job) throw(err)
     var name = job.attrs.name;
 
-    if (self._runningJobs.indexOf(job) == -1) throw("callback already called - job already marked complete");
+    if (self._runningJobs.indexOf(job) == -1) throw("callback already called - job " + name + " already marked complete");
 
     self._runningJobs.splice(self._runningJobs.indexOf(job), 1);
     if (definitions[name].running > 0) definitions[name].running--;


### PR DESCRIPTION
We had an issue where the job done callback was being over executed. This made the global job level running and lock counters to go negative. Then agenda would stop obeying concurrency limits. This prevents the job counter from ever going negative and adds an exception if code calls the job done more than once. 